### PR TITLE
Support python 3.12

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -13,7 +13,8 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        os: [ubuntu-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v2
@@ -43,6 +44,7 @@ jobs:
     - name: Run tests
       run: |
 
+        python3 -m pip freeze # required to report issue to py-trie
         python3 -m unittest
 
         rm -f coverage.xml

--- a/README.rst
+++ b/README.rst
@@ -14,10 +14,10 @@ Python support for the offline verification of scitt receipts for rkvst events.
 Python Support
 ==============
 
-This package currently is tested against Python versions 3.7,3.8,3.9, 3.10 and 3.11.
+This package currently is tested against Python versions 3.8,3.9,3.10,3.11 and 3.12.
 
-The current default version is 3.7 - this means that this package will not
-use any features specific to versions 3.8 and later.
+The current default version is 3.8 - this means that this package will not
+use any features specific to versions 3.9 and later.
 
 After End of Life of a particular Python version, support is offered on a best effort
 basis. We may ask you to update your Python version to help solve the problem,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,12 @@
 -r requirements.txt
 
 # code quality
-autopep8~=1.6
-black~=22.10
-coverage[toml]~=6.5
-pip-audit~=2.4
-pycodestyle~=2.9
-pylint~=2.14
+autopep8~=2.0
+black~=23.9
+coverage[toml]~=7.3
+pip-audit~=2.6
+pycodestyle~=2.10
+pylint~=3.0
 xq~=0.0
 
 # docs
@@ -18,5 +18,5 @@ sphinxcontrib-spelling~=8.0.0
 sphinx-mdinclude~=0.5.3
 
 # uploading to pypi
-build~=0.8
+build~=1.0
 twine~=4.0

--- a/rkvst_receipt_scitt/elementmetadata.py
+++ b/rkvst_receipt_scitt/elementmetadata.py
@@ -185,7 +185,6 @@ class FieldValues:
         islotvalue = 0
         storageslot = 0
         for field in metadata["fields"]:
-
             # every time the storage slot changes we bump the index into our
             # slotvalues array. This is a bit awkward, we will likely change the
             # metadata to make it less so.

--- a/rkvst_receipt_scitt/khipureceipt.py
+++ b/rkvst_receipt_scitt/khipureceipt.py
@@ -107,7 +107,6 @@ class KhipuReceipt(Receipt):
         eventattributes = {}
 
         for kindname, rlpvalue in zip(kindnames, values):
-
             kind, name = decode_attribute_key(kindname)
 
             value = decode_attribute_value(rlpvalue)


### PR DESCRIPTION
Upgrade pylint to 3.0 and other tools
Also drop support for python 3.7 (EOL 2023-06-27)
Add supoort for windows.
Made sure that code was reformatted according to black.
